### PR TITLE
Allow compatibility for the current minor release

### DIFF
--- a/ClassicAuraDurations.toc
+++ b/ClassicAuraDurations.toc
@@ -1,4 +1,4 @@
-## Interface: 11302
+## Interface: 11303
 ## Title: ClassicAuraDurations
 ## Author: d87
 ## SavedVariables: ClassicAuraDurationsDB

--- a/ClassicAuraDurations.toc
+++ b/ClassicAuraDurations.toc
@@ -1,4 +1,4 @@
-## Interface: 11303
+## Interface: 11300
 ## Title: ClassicAuraDurations
 ## Author: d87
 ## SavedVariables: ClassicAuraDurationsDB


### PR DESCRIPTION
Ignore patch releases and target the current minor release so that the addon doesn't always appear out of date with Blizzard soft patches.

![image](https://user-images.githubusercontent.com/6037730/72073861-094d9880-32ae-11ea-9594-2618d0c90dab.png)
