### PR TITLE
Update to new Settings API.

### DIFF
--- a/code.lua
+++ b/code.lua
@@ -355,13 +355,14 @@ end
     end)
     ]]
 
-    local loader = CreateFrame('Frame', nil, SettingsPanel or InterfaceOptionsFrame)
+    local loader = CreateFrame('Frame', nil, SettingsPanel)
         loader:SetScript('OnShow', function(self)
             self:SetScript('OnShow', nil)
 
             if not f.optionsPanel then
                 f.optionsPanel = f:CreateGUI("ClassicAuraDurations")
-                InterfaceOptions_AddCategory(f.optionsPanel);
+                f.optionsPanel.category = Settings.RegisterCanvasLayoutCategory(f.optionsPanel, "ClassicAuraDurations")
+                Settings.RegisterAddOnCategory(f.optionsPanel.category)
             end
         end)
 end
@@ -444,7 +445,7 @@ local function AddTooltip(widget, tooltipText)
 end
 
 function f:CreateGUI(name, parent)
-    local frame = CreateFrame("Frame", nil, InterfaceOptionsFrame)
+    local frame = CreateFrame("Frame")
     frame:Hide()
 
     frame.parent = parent


### PR DESCRIPTION
In the latest updates to 1.15.5 the deprecated `InterfaceOptions_*` API is removed and the new Settings API must be used, to be more in the lines of retail.